### PR TITLE
Preview4 changes to make fully WindowsPowerShell compatible.

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -161,6 +161,13 @@ stages:
 
   - template: test.yml
     parameters:
+      jobName: TestPkgWinPS
+      displayName: Windows PowerShell on Windows
+      imageName: windows-2019
+      powershellExecutable: powershell
+
+  - template: test.yml
+    parameters:
       jobName: TestPkgUbuntu16
       displayName: PowerShell Core on Ubuntu 16.04
       imageName: ubuntu-16.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 0.5.4-preview4 - 2020-11-16
+
+### Fixes
+
+- Windows PowerShell incompatibility when creating new store files (Issue #28).
+
+### Changes
+
+- SecretStore binary is now built against net461 to provide full compatibility when run in PowerShell 6+ or WindowsPowerShell.
+
+- `System.IO.FileSystem.AccessControl.dll` is now shipped with module to maintain compatibility with WindowsPowerShell.
+
+### New Features
+
 ## 0.5.3-Preview3 - 2020-11-4
 
 ### Fixes
@@ -16,7 +30,7 @@
 
 - `Reset-SecretStore` now has a new `-Password` and `-PassThru` parameter.
 
-- `Reset-SecretStore` will now prompt immediately for a new password, if password authentication is selected and prompt interaction is allowed (Issue #34)
+- `Reset-SecretStore` will now prompt immediately for a new password, if password authentication is selected and prompt interaction is allowed (Issue #34).
 
 ### New Features
 

--- a/build.ps1
+++ b/build.ps1
@@ -36,8 +36,8 @@ param (
     [ValidateSet("Debug", "Release")]
     [string] $BuildConfiguration = "Debug",
 
-    [ValidateSet("netstandard2.0")]
-    [string] $BuildFramework = "netstandard2.0"
+    [ValidateSet("net461")]
+    [string] $BuildFramework = "net461"
 )
 
 if ( ! (Get-Module -ErrorAction SilentlyContinue PSPackageProject -ListAvailable)) {

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -39,8 +39,6 @@ function DoBuild
             Write-Verbose -Verbose -Message "Building location: PSScriptRoot: $PSScriptRoot, PWD: $pwd"
             dotnet publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath
 
-            # Debug: Check 
-
             # Place build results
             if (! (Test-Path -Path "$BuildSrcPath/${ModuleName}.dll"))
             {
@@ -48,13 +46,16 @@ function DoBuild
             }
 
             Write-Verbose -Verbose -Message "Copying $BuildSrcPath/${ModuleName}.dll to $BuildOutPath"
-            Copy-Item "$BuildSrcPath/${ModuleName}.dll" -Dest "$BuildOutPath"
+            Copy-Item -Path "$BuildSrcPath/${ModuleName}.dll" -Dest "$BuildOutPath"
             
             if (Test-Path -Path "$BuildSrcPath/${ModuleName}.pdb")
             {
                 Write-Verbose -Verbose -Message "Copying $BuildSrcPath/${ModuleName}.pdb to $BuildOutPath"
                 Copy-Item -Path "$BuildSrcPath/${ModuleName}.pdb" -Dest "$BuildOutPath"
             }
+
+            Write-Verbose -Verbose "$BuildSrcPath/System.IO.FileSystem.AccessControl.dll to $BuildOutPath"
+            Copy-Item -Path "$BuildSrcPath/System.IO.FileSystem.AccessControl.dll" -Dest "$BuildOutPath"
         }
         catch {
             # Write-Error "dotnet build failed with error: $_"

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '0.5.3'
+ModuleVersion = '0.5.4'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')
@@ -68,7 +68,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        Prerelease = 'preview3'
+        Prerelease = 'preview4'
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,20 +5,16 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>0.5.3.0</AssemblyVersion>
-    <FileVersion>0.5.3</FileVersion>
-    <InformationalVersion>0.5.3</InformationalVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
+    <AssemblyVersion>0.5.4.0</AssemblyVersion>
+    <FileVersion>0.5.4</FileVersion>
+    <InformationalVersion>0.5.4</InformationalVersion>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SecretManagement.Library" Version="0.5.1-*" />
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-*" />
-    <PackageReference Include="Microsoft.CSharp" version="4.5.0-*" />
+    <PackageReference Include="Microsoft.PowerShell.SecretManagement.Library" Version="0.5.5-*" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
+    <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" version="4.7.0" />
   </ItemGroup>
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -2553,10 +2553,8 @@ namespace Microsoft.PowerShell.SecretStore
             // Windows platform.
 
             // For Windows, file permissions are set to FullAccess for current user account only.
-            var dirInfo = new DirectoryInfo(directoryPath);
-            var dirSecurity = new DirectorySecurity();
-
             // SetAccessRule method applies to this directory.
+            var dirSecurity = new DirectorySecurity();
             dirSecurity.SetAccessRule(
                 new FileSystemAccessRule(
                     identity: WindowsIdentity.GetCurrent().User,
@@ -2582,8 +2580,10 @@ namespace Microsoft.PowerShell.SecretStore
             // Set directory owner.
             dirSecurity.SetOwner(WindowsIdentity.GetCurrent().User);
 
-            // Apply rules.
-            dirInfo.SetAccessControl(dirSecurity);
+            // Apply new rules.
+            System.IO.FileSystemAclExtensions.SetAccessControl(
+                directoryInfo: new DirectoryInfo(directoryPath),
+                directorySecurity: dirSecurity);
         }
 
         private static void SetFilePermissions(

--- a/test/Microsoft.PowerShell.SecretStore.Tests.ps1
+++ b/test/Microsoft.PowerShell.SecretStore.Tests.ps1
@@ -5,6 +5,13 @@ Describe "Test Microsoft.PowerShell.SecretStore module" -tags CI {
 
     BeforeAll {
 
+        if (($IsWindows -eq $true) -or ($PSVersionTable.PSVersion.Major -eq 5)) {
+            $IsWindowsPlatform = $true
+        }
+        else {
+            $IsWindowsPlatform = $false;
+        }
+
         if ((Get-Module -Name Microsoft.PowerShell.SecretManagement -ErrorAction Ignore) -eq $null)
         {
             Import-Module -Name Microsoft.PowerShell.SecretManagement
@@ -41,7 +48,7 @@ Describe "Test Microsoft.PowerShell.SecretStore module" -tags CI {
     Context "SecretStore file permission tests" {
 
         BeforeAll {
-            if ($IsWindows)
+            if ($IsWindowsPlatform)
             {
                 $storePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)
                 $storePath = Join-Path -Path $storePath -ChildPath 'Microsoft\PowerShell\secretmanagement\localstore'
@@ -58,7 +65,7 @@ Describe "Test Microsoft.PowerShell.SecretStore module" -tags CI {
             }
         }
 
-        if ($IsWindows)
+        if ($IsWindowsPlatform)
         {
             It "Verifies SecretStore directory ACLs" {
                 $acl = Get-Acl $storePath


### PR DESCRIPTION
This PR modifies the SecretStore binary build to target the net461 framework, so that it can be compatible with WindowsPowerShell as well as PowerShell core.  Previously WindowsPowerShell would throw a type exception if used to create a new store, because .NET AccessControl APIs are different between net461 and netstandard2.0 frameworks.

