### PR TITLE
Add RC3 release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### New Features
 
-- `Set-SecretStoreConfiguration` command now takes a `-password` parameter so that there is not need to prompt for a password (Issue #46).
+- `Set-SecretStoreConfiguration` command now takes a `-Password` parameter so that there is not need to prompt for a password (Issue #46).
 
 ## 0.9.1 - 2021-3-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 0.9.2 - 2021-3-15
+
+### Fixes
+
+- Minor changes to help file format.
+
+### Changes
+
+- The `-Force` parameter was removed from the `Set-SecretStoreConfiguration` command, and instead the `-Confirm:$false` should be used to suppress PowerShell prompting in automation scripts.
+
+### New Features
+
+- `Set-SecretStoreConfiguration` command now takes a `-password` parameter so that there is not need to prompt for a password (Issue #46).
+
 ## 0.9.1 - 2021-3-1
 
 ### Fixes

--- a/help/Get-SecretStoreConfiguration.md
+++ b/help/Get-SecretStoreConfiguration.md
@@ -21,17 +21,14 @@ This cmdlet reads the SecretStore configuration file and writes configuration in
 Configuration information includes:
 
 - Scope
-
 - Authentication
-
 - PasswordTimeout (in seconds)
-
 - Interaction
 
 ## EXAMPLES
 
 ### Example 1
-```powershell
+```
 PS C:\> Get-SecretStoreConfiguration
 
       Scope Authentication PasswordTimeout Interaction
@@ -39,11 +36,10 @@ PS C:\> Get-SecretStoreConfiguration
 CurrentUser       Password             900      Prompt
 ```
 
-This example runs the command from a command shell prompt and displays four SecretStore configuration properties:  
-Scope : 'CurrentUser'.  
-Authentication : A password is required to access the SecretStore.  
-PasswordTimeout : The session password timeout time is 15 minutes.  
-Interaction : The user will be prompted for a password if the command is run in an interactive session.  
+This example runs the command from a command shell prompt and displays four SecretStore configuration properties: Scope : 'CurrentUser'.
+Authentication : A password is required to access the SecretStore.
+PasswordTimeout : The session password timeout time is 15 minutes.
+Interaction : The user will be prompted for a password if the command is run in an interactive session.
 
 ## PARAMETERS
 
@@ -53,13 +49,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### None
-
 ## OUTPUTS
 
 ### Microsoft.PowerShell.SecretStore.SecureStoreConfig
-
 ## NOTES
-
-'AllUsers' scope is currently not supported.  Configuration scope is always 'CurrentUser'.
+'AllUsers' scope is currently not supported. 
+Configuration scope is always 'CurrentUser'.
 
 ## RELATED LINKS

--- a/help/Reset-SecretStore.md
+++ b/help/Reset-SecretStore.md
@@ -13,19 +13,20 @@ Resets the SecretStore by deleting all secret data and configuring the store wit
 ## SYNTAX
 
 ```
-Reset-SecretStore [-Scope <SecureStoreScope>] [-Authentication <Authenticate>] [-PasswordTimeout <Int32>]
- [-Interaction <Interaction>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Reset-SecretStore [-Scope <SecureStoreScope>] [-Authentication <Authenticate>] [-Password <SecureString>]
+ [-PasswordTimeout <Int32>] [-Interaction <Interaction>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 This cmdlet completely resets the SecretStore by deleting all secret data it may contain, and resetting configuration options to their default values.
-It is intended to be used only if a required password is lost, or data files become corrupted so that SecretStore no longer functions and secret data cannot be accessed.  
+It is intended to be used only if a required password is lost, or data files become corrupted so that SecretStore no longer functions and secret data cannot be accessed.
 Default configuration options can be overridden by specifying individual command configuration option parameters.
 
 ## EXAMPLES
 
 ### Example 1
-```powershell
+```
 PS C:\> Reset-SecretStore -PassThru
 WARNING: !!This operation will completely remove all SecretStore module secrets and reset configuration settings to default values!!
 
@@ -93,7 +94,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value:
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -203,11 +204,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### None
-
 ## OUTPUTS
 
 ### Microsoft.PowerShell.SecretStore.SecureStoreConfig
-
 ## NOTES
 
 ## RELATED LINKS

--- a/help/Set-SecretStorePassword.md
+++ b/help/Set-SecretStorePassword.md
@@ -12,8 +12,14 @@ Replaces the current SecretStore password with a new one.
 
 ## SYNTAX
 
+### NoParameterSet (Default)
 ```
 Set-SecretStorePassword [<CommonParameters>]
+```
+
+### ParameterSet
+```
+Set-SecretStorePassword -NewPassword <SecureString> [-Password <SecureString>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,7 +29,7 @@ It takes no parameters and prompts the user for both the old and new passwords.
 ## EXAMPLES
 
 ### Example 1
-```powershell
+```
 PS C:\> Set-SecretStorePassword
 Old password
 Enter password:
@@ -40,12 +46,11 @@ The user is first prompted for the old password.
 And then prompted for the new password twice for verification.
 
 ### Example 2
-```powershell
+```
 PS C:\> Set-SecretStorePassword -NewPassword $newPassword -Password $oldPassword
 ```
 
-This example runs the command passing in both the current store password and the new
-password to be set.
+This example runs the command passing in both the current store password and the new password to be set.
 
 ## PARAMETERS
 
@@ -59,8 +64,8 @@ Aliases:
 
 Required: True
 Position: Named
-Default value:
-Accept pipeline input: True
+Default value: None
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -75,7 +80,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value:
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -86,7 +91,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### None
-
 ## OUTPUTS
 
 ## NOTES

--- a/help/Unlock-SecretStore.md
+++ b/help/Unlock-SecretStore.md
@@ -25,7 +25,7 @@ If no password is provided by parameter argument, the user will be safely prompt
 ## EXAMPLES
 
 ### Example 1
-```powershell
+```
 PS C:\> Get-Secret secret1 -Vault LocalStore
 Get-Secret: A valid password is required to access the Microsoft.PowerShell.SecretStore vault.
 Get-Secret: The secret secret1 was not found.
@@ -84,7 +84,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Security.SecureString
-
 ## OUTPUTS
 
 ## NOTES

--- a/help/en-US/Microsoft.PowerShell.SecretStore.dll-Help.xml
+++ b/help/en-US/Microsoft.PowerShell.SecretStore.dll-Help.xml
@@ -56,12 +56,7 @@
       ----- -------------- --------------- -----------
 CurrentUser       Password             900      Prompt</dev:code>
         <dev:remarks>
-          <maml:para>This example runs the command from a command shell prompt and displays four SecretStore configuration properties:
-Scope : 'CurrentUser'.
-Authentication : A password is required to access the SecretStore.
-PasswordTimeout : The session password timeout time is 15 minutes.
-Interaction : The user will be prompted for a password if the command is run in an interactive session.
-</maml:para>
+          <maml:para>This example runs the command from a command shell prompt and displays four SecretStore configuration properties: Scope : 'CurrentUser'. Authentication : A password is required to access the SecretStore. PasswordTimeout : The session password timeout time is 15 minutes. Interaction : The user will be prompted for a password if the command is run in an interactive session.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -77,8 +72,7 @@ Interaction : The user will be prompted for a password if the command is run in 
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>This cmdlet completely resets the SecretStore by deleting all secret data it may contain, and resetting configuration options to their default values. It is intended to be used only if a required password is lost, or data files become corrupted so that SecretStore no longer functions and secret data cannot be accessed.
-Default configuration options can be overridden by specifying individual command configuration option parameters.</maml:para>
+      <maml:para>This cmdlet completely resets the SecretStore by deleting all secret data it may contain, and resetting configuration options to their default values. It is intended to be used only if a required password is lost, or data files become corrupted so that SecretStore no longer functions and secret data cannot be accessed. Default configuration options can be overridden by specifying individual command configuration option parameters.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -381,17 +375,6 @@ CurrentUser       Password             900      Prompt</dev:code>
           <dev:defaultValue>Password</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Force</maml:name>
-          <maml:Description>
-            <maml:para>When used, the user will not be asked to confirm and the SecretStore will be reset without prompting. Default value is false, and user will be asked to confirm the operation.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>PassThru</maml:name>
           <maml:Description>
             <maml:para>When used, will write the current SecretStore configuration to the pipeline.</maml:para>
@@ -401,6 +384,18 @@ CurrentUser       Password             900      Prompt</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Password</maml:name>
+          <maml:Description>
+            <maml:para>Password to be applied when changing the authentication configuration. When changing the configuration from no password required to password required, the provided password will be set as the new store password. When changing the configuration from password required to no password required, the provided password will be used to authorize the configuration change, and must be the current password used to unlock the store. This command cannot be used to change the store password. To change an existing password, use the `Set-SecretStorePassword` command.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>PasswordTimeout</maml:name>
@@ -479,17 +474,6 @@ CurrentUser       Password             900      Prompt</dev:code>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Force</maml:name>
-          <maml:Description>
-            <maml:para>When used, the user will not be asked to confirm and the SecretStore will be reset without prompting. Default value is false, and user will be asked to confirm the operation.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>PassThru</maml:name>
           <maml:Description>
             <maml:para>When used, will write the current SecretStore configuration to the pipeline.</maml:para>
@@ -499,6 +483,18 @@ CurrentUser       Password             900      Prompt</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Password</maml:name>
+          <maml:Description>
+            <maml:para>Password to be applied when changing the authentication configuration. When changing the configuration from no password required to password required, the provided password will be set as the new store password. When changing the configuration from password required to no password required, the provided password will be used to authorize the configuration change, and must be the current password used to unlock the store. This command cannot be used to change the store password. To change an existing password, use the `Set-SecretStorePassword` command.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
@@ -550,18 +546,6 @@ CurrentUser       Password             900      Prompt</dev:code>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>Force</maml:name>
-        <maml:Description>
-          <maml:para>When used, the user will not be asked to confirm and the SecretStore will be reset without prompting. Default value is false, and user will be asked to confirm the operation.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>PassThru</maml:name>
         <maml:Description>
           <maml:para>When used, will write the current SecretStore configuration to the pipeline.</maml:para>
@@ -572,6 +556,18 @@ CurrentUser       Password             900      Prompt</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Password</maml:name>
+        <maml:Description>
+          <maml:para>Password to be applied when changing the authentication configuration. When changing the configuration from no password required to password required, the provided password will be set as the new store password. When changing the configuration from password required to no password required, the provided password will be used to authorize the configuration change, and must be the current password used to unlock the store. This command cannot be used to change the store password. To change an existing password, use the `Set-SecretStorePassword` command.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>PasswordTimeout</maml:name>
@@ -676,6 +672,37 @@ CurrentUser       Password             900      Prompt</dev:code>
           <maml:para>This example uses the command to restore the SecretStore configuration settings to their default values.</maml:para>
         </dev:remarks>
       </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>Install-Module -Name Microsoft.PowerShell.SecretStore -Repository PSGallery -Force
+$password = Import-CliXml -Path $securePasswordPath.xml
+Set-SecretStoreConfiguration -Scope CurrentUser -Authentication Password -PasswordTimeout 3600 -Interaction None -Password $password -Confirm:$false
+
+Install-Module -Name Microsoft.PowerShell.SecretManagement -Repository PSGallery -Force
+Register-SecretVault -Name SecretStore -ModuleName Microsoft.PowerShell.SecretStore -DefaultVault
+
+Unlock-SecretStore -Password $password</dev:code>
+        <dev:remarks>
+          <maml:para>This is an example of automation script that installs and configures the Microsoft.PowerShell.SecretStore module without user prompting. The configuration requires a password and sets user interaction to None, so that SecretStore will never prompt the user. The configuration also requires a password, and the password is passed in as a SecureString object. The `-Confirm:false` parameter is used so that PowerShell will not prompt for confirmation.</maml:para>
+          <maml:para>Next, the SecretManagement module is installed and the SecretStore module registered so that  the SecretStore secrets can be managed.</maml:para>
+          <maml:para>The `Unlock-SecretStore` cmdlet is used to unlock the SecretStore for this session. The password timeout was configured for 1 hour and SecretStore will remain unlocked in the session for that amount of time, after which it will need to be unlocked again before secrets can be accessed.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-SecretStoreConfiguration
+
+      Scope Authentication PasswordTimeout Interaction
+      ----- -------------- --------------- -----------
+CurrentUser       Password             900        None
+
+PS C:\&gt; Set-SecretStoreConfiguration -Authentication Password -Password $password
+Set-SecretStoreConfiguration: The Microsoft.PowerShell.SecretStore is already configured to require a password, and a new password cannot be added.
+Use the Set-SecretStorePassword cmdlet to change an existing password.</dev:code>
+        <dev:remarks>
+          <maml:para>This example attempts to set the SecretStore configuration to require a password and provides a new password. But this results in an error. This command cannot be used to change an existing password but only to toggle authentication to require or not require a password. To change an existing SecretStore password, use the `Set-SecretStorePassword` command.</maml:para>
+        </dev:remarks>
+      </command:example>
     </command:examples>
     <command:relatedLinks />
   </command:command>
@@ -694,7 +721,7 @@ CurrentUser       Password             900      Prompt</dev:code>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Set-SecretStorePassword</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
           <maml:name>NewPassword</maml:name>
           <maml:Description>
             <maml:para>New password to be applied to the store.</maml:para>
@@ -721,7 +748,7 @@ CurrentUser       Password             900      Prompt</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
         <maml:name>NewPassword</maml:name>
         <maml:Description>
           <maml:para>New password to be applied to the store.</maml:para>

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '0.9.1'
+ModuleVersion = '0.9.2'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')
@@ -56,7 +56,7 @@ PrivateData = @{
         Tags = @('SecretManagement')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/PowerShell/Modules/License.txt'
+        LicenseUri = 'https://github.com/PowerShell/SecretStore/blob/master/LICENSE'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/powershell/secretstore'

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>0.9.1.0</AssemblyVersion>
-    <FileVersion>0.9.1</FileVersion>
-    <InformationalVersion>0.9.1</InformationalVersion>
+    <AssemblyVersion>0.9.2.0</AssemblyVersion>
+    <FileVersion>0.9.2</FileVersion>
+    <InformationalVersion>0.9.2</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 

--- a/test/Microsoft.PowerShell.SecretStore.Tests.ps1
+++ b/test/Microsoft.PowerShell.SecretStore.Tests.ps1
@@ -42,7 +42,7 @@ Describe "Test Microsoft.PowerShell.SecretStore module" -tags CI {
         # This deletes all SecretStore data!!
         Write-Warning "!!! These tests will remove all secrets in the store for the current user !!!"
         Reset-SecretStore -Scope CurrentUser -Authentication None -PasswordTimeout -1 -Interaction None -Force
-        $null = Set-SecretStoreConfiguration -Scope CurrentUser -Authentication None -PasswordTimeout -1 -Interaction None -Force
+        $null = Set-SecretStoreConfiguration -Scope CurrentUser -Authentication None -PasswordTimeout -1 -Interaction None -Confirm:$false
     }
 
     Context "SecretStore file permission tests" {


### PR DESCRIPTION
These changes to the following:

* Remove the `-Force` parameter from `Set-SecretStoreConfiguration` cmdlet. The `-Confirm:$false` parameter should now be used to prevent PowerShell from prompting for confirmation.

* Add `-Password` parameter to `Set-SecretStoreConfiguration` cmdlet. This new parameter allows a password to be passed in as a cmdlet argument so that prompting is not needed.

* Fix the manifest license Url.

* Update and fix help files.  Help files were not compiling into xml correctly before.