### PR TITLE
Address issues for v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 - Add better error message when running under Windows built-in accounts (Issue #63).
 
-- Store update no longer removes current information on read failure (Issue ??).
+- Store update no longer removes current information on read failure.
 
 ### Changes
+
+- Add support for SecretManagement `Unlock-SecretVault` command.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 1.1.0 - 2021-5-10
+
+### Fixes
+
+- Metadata does not accept datetime from Get-Date (Issue #59).
+
+- SecretStore requires Full Language mode (Issue #64).
+
+- Add better error message when running under Windows built-in accounts (Issue #63).
+
+### Changes
+
+### New Features
+
 ## 1.0.0 - 2021-3-25
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # CHANGELOG
 
-## 1.0.1 - 2021-5-17
+## 1.0.2 - 2021-5-17
 
 ### Fixes
 
 - Metadata does not accept datetime from Get-Date (Issue #59).
 
 - Add better error message when running under Windows built-in accounts (Issue #63).
+
+- Store update no longer removes current information on read failure (Issue ??).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # CHANGELOG
 
-## 1.1.0 - 2021-5-10
+## 1.0.1 - 2021-5-17
 
 ### Fixes
 
 - Metadata does not accept datetime from Get-Date (Issue #59).
-
-- SecretStore requires Full Language mode (Issue #64).
 
 - Add better error message when running under Windows built-in accounts (Issue #63).
 

--- a/src/Microsoft.PowerShell.SecretStore.Extension/Microsoft.PowerShell.SecretStore.Extension.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.Extension/Microsoft.PowerShell.SecretStore.Extension.psd1
@@ -1,6 +1,15 @@
 @{
     ModuleVersion = '1.0'
+    GUID = 'b8977c8d-309d-4732-ba29-6233fdd6278b'
+    Author = 'Microsoft Corporation'
+    CompanyName = 'Microsoft Corporation'
+    Copyright = '(c) Microsoft Corporation. All rights reserved.'
+    Description = 'Extension vault submodule for SecretStore.'
+    PowerShellVersion = '5.1'
+    DotNetFrameworkVersion = '4.6.1'
+    CLRVersion = '4.0.0'    
     RootModule = 'Microsoft.PowerShell.SecretStore.Extension.psm1'
     RequiredAssemblies = '../Microsoft.PowerShell.SecretStore.dll'
     FunctionsToExport = @('Set-Secret','Set-SecretInfo','Get-Secret','Remove-Secret','Get-SecretInfo','Test-SecretVault')
+    PrivateData = @{ PSData = @{ ProjectUri = 'https://github.com/powershell/secretstore' } }
 }

--- a/src/Microsoft.PowerShell.SecretStore.Extension/Microsoft.PowerShell.SecretStore.Extension.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.Extension/Microsoft.PowerShell.SecretStore.Extension.psd1
@@ -10,6 +10,6 @@
     CLRVersion = '4.0.0'    
     RootModule = 'Microsoft.PowerShell.SecretStore.Extension.psm1'
     RequiredAssemblies = '../Microsoft.PowerShell.SecretStore.dll'
-    FunctionsToExport = @('Set-Secret','Set-SecretInfo','Get-Secret','Remove-Secret','Get-SecretInfo','Test-SecretVault')
+    FunctionsToExport = @('Set-Secret','Set-SecretInfo','Get-Secret','Remove-Secret','Get-SecretInfo','Unlock-SecretVault','Test-SecretVault')
     PrivateData = @{ PSData = @{ ProjectUri = 'https://github.com/powershell/secretstore' } }
 }

--- a/src/Microsoft.PowerShell.SecretStore.Extension/Microsoft.PowerShell.SecretStore.Extension.psm1
+++ b/src/Microsoft.PowerShell.SecretStore.Extension/Microsoft.PowerShell.SecretStore.Extension.psm1
@@ -267,6 +267,31 @@ function Remove-Secret
     Write-Error -ErrorRecord $errorRecord
 }
 
+function Unlock-SecretVault
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
+    [CmdletBinding()]
+    param (
+        [SecureString] $Password,
+        [hashtable] $CredentialInfo,
+        [string] $VaultName,
+        [hashtable] $AdditionalParameters
+    )
+
+    $errorMsg = ""    
+    if (! [Microsoft.PowerShell.SecretStore.LocalSecretStore]::UnlockVault($Password, [ref] $errorMsg))
+    {
+        $Msg = "$VaultName Vault Unlock operation failed with error: $errorMsg"
+
+        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Security.Authentication.AuthenticationException]::new($Msg),
+            "SecretStoreUnlockFailed",
+            [System.Management.Automation.ErrorCategory]::AuthenticationError,
+            $null)
+        Write-Error -ErrorRecord $errorRecord
+    }
+}
+
 function Test-SecretVault
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.0.2'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -41,6 +41,8 @@ https://github.com/powershell/SecretStore
 
 # Minimum version of the PowerShell engine required by this module
 PowerShellVersion = '5.1'
+DotNetFrameworkVersion = '4.6.1'
+CLRVersion = '4.0.0'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @('Unlock-SecretStore','Set-SecretStorePassword','Get-SecretStoreConfiguration','Set-SecretStoreConfiguration','Reset-SecretStore')

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '1.1.0'
+ModuleVersion = '1.0.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1</FileVersion>
-    <InformationalVersion>1.0.1</InformationalVersion>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2</FileVersion>
+    <InformationalVersion>1.0.2</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
-    <InformationalVersion>1.0.0</InformationalVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0</FileVersion>
+    <InformationalVersion>1.1.0</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0</FileVersion>
-    <InformationalVersion>1.1.0</InformationalVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1</FileVersion>
+    <InformationalVersion>1.0.1</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1489,19 +1489,18 @@ namespace Microsoft.PowerShell.SecretStore
 
         public void UpdateDataFromFile()
         {
-            SecureStoreData data;
-            if (!SecureStoreFile.ReadFile(
+            if (SecureStoreFile.ReadFile(
                 password: _password,
-                data: out data,
+                data: out SecureStoreData data,
                 out string _))
             {
-                data = SecureStoreData.CreateEmpty();
+                lock (_syncObject)
+                {
+                    _data = data;
+                }
             }
             
-            lock (_syncObject)
-            {
-                _data = data;
-            }
+            // If file read fails (e.g., password expired), then skip the update.
         }
 
         #endregion

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.SecretStore
         public static PSObject ConvertJsonToPSObject(string json)
         {
             var results = PowerShellInvoker.InvokeScriptCommon<PSObject>(
-                script: @"param ([string] $json) ConvertFrom-Json -InputObject $json",
+                script: @"param ([string] $json) Microsoft.PowerShell.Utility\ConvertFrom-Json -InputObject $json",
                 args: new object[] { json },
                 error: out ErrorRecord _);
 
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.SecretStore
         public static string ConvertHashtableToJson(Hashtable hashtable)
         {
             var results = PowerShellInvoker.InvokeScriptCommon<string>(
-                script: @"param ([hashtable] $hashtable) ConvertTo-Json -InputObject $hashtable -Depth 5",
+                script: @"param ([hashtable] $hashtable) Microsoft.PowerShell.Utility\ConvertTo-Json -InputObject $hashtable -Depth 5",
                 args: new object[] { hashtable },
                 error: out ErrorRecord _);
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -3003,21 +3003,29 @@ namespace Microsoft.PowerShell.SecretStore
             return LocalStore;
         }
 
-        public static void Reset()
-        {
-            lock (SyncObject)
-            {
-                LocalStore?.Dispose();
-                LocalStore = null;
-            }
-        }
-
         public static void PromptAndUnlockVault(
             string vaultName,
             PSCmdlet cmdlet)
         {
             var password = PromptForPassword(vaultName, cmdlet);
             LocalSecretStore.GetInstance(password).UnlockLocalStore(password);
+        }
+
+        public static bool UnlockVault(
+            SecureString password,
+            out string errorMsg)
+        {
+            try
+            {
+                LocalSecretStore.GetInstance(password).UnlockLocalStore(password);
+                errorMsg = string.Empty;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                errorMsg = ex.Message;
+                return false;
+            }
         }
 
         #endregion
@@ -3243,6 +3251,15 @@ namespace Microsoft.PowerShell.SecretStore
             if (passwordTimeout.HasValue)
             {
                 _secureStore.SetPasswordTimer(passwordTimeout.Value);
+            }
+        }
+
+        internal static void Reset()
+        {
+            lock (SyncObject)
+            {
+                LocalStore?.Dispose();
+                LocalStore = null;
             }
         }
 

--- a/test/Microsoft.PowerShell.SecretStore.Tests.ps1
+++ b/test/Microsoft.PowerShell.SecretStore.Tests.ps1
@@ -220,6 +220,15 @@ Describe "Test Microsoft.PowerShell.SecretStore module" -tags CI {
             $success | Should -Not -BeTrue
         }
 
+        It "Verifies [datetime] type wrapped in a PSObject" {
+            $errorMsg = ""
+            $success = [Microsoft.PowerShell.SecretStore.LocalSecretStore]::GetInstance().WriteMetadata(
+                $secretName,
+                (@{ Created = (Get-Date) }),
+                [ref] $errorMsg)
+            $success | Should -BeTrue
+        }
+
         It "Verifies expected no secret found error" {
             $errorMsg = ""
             $success = [Microsoft.PowerShell.SecretStore.LocalSecretStore]::GetInstance().WriteMetadata(


### PR DESCRIPTION
This PR has a number of changes that have been marked for v1.0.2 release.

- Metadata parameter now accepts datetime from the Get-Date cmdlet
- Better error message when used in unsupported Windows built-in accounts (Windows only)
- Add support for new SecretManament 'Unlock-SecretVault' command.
