### PR TITLE
Remove unneeded triggers

### DIFF
--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -1,14 +1,6 @@
 name: $(BuildDefinitionName)-$(date:yyMM).$(date:dd)$(rev:rrr)
-trigger:
-  # Batch merge builds together while a merge build is running
-  batch: false
-  branches:
-    include:
-    - master
-pr:
-  branches:
-    include:
-    - master
+trigger: none
+pr: none
 
 variables:
   - group: ESRP


### PR DESCRIPTION
Release is always triggered manually.