### PR TITLE
Fix race condition when updating password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 1.0.3 - 2021-8-12
+
+### Fixes
+
+- Fix race condition where updating store configuration fails with invalid password (Issue #79).
+
+- Update password failure errors are now surfaced to users (Issue #79).
+
+- Fix for random data corruption when password is updated.
+
+### Changes
+
+### New Features
+
 ## 1.0.2 - 2021-5-17
 
 ### Fixes

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.0.3'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>1.0.2.0</AssemblyVersion>
-    <FileVersion>1.0.2</FileVersion>
-    <InformationalVersion>1.0.2</InformationalVersion>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <FileVersion>1.0.3</FileVersion>
+    <InformationalVersion>1.0.3</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR fixes three problems found when investigation Issue (#79).

- There was a race condition that prevented changing password (either directly or through changing store configuration), where the password variable reference is cleared before it is through being used.  Fix is to pass a copy of the password so that the source variable reference can be used repeatedly.

- Error information when updating the configuration failed, was not being surfaced, causing confusion when update failed.

- Updating the password would sometimes corrupt the store data, because of ordering changes in the metadata.  Fix is to directly set metadata blob offset and size information during update.