### PR TITLE
Bug fixes for 1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.0.4 - 2021-8-30
+
+### Fixes
+
+- Workaround Windows bug where UserName environment variable is incorrect case (Issue #62).
+
+### Changes
+
+### New Features
+
 ## 1.0.3 - 2021-8-12
 
 ### Fixes

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '1.0.3'
+ModuleVersion = '1.0.4'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3</FileVersion>
-    <InformationalVersion>1.0.3</InformationalVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4</FileVersion>
+    <InformationalVersion>1.0.4</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR contains a bug fix for Issue #62, where previously the system environment variable was used to obtain the current user name.  However, on Windows platforms, the user name may be with the incorrect character casing.  This fix uses the .NET WindowsIdentity API to get the current user name, which will always have the correct casing.