### PR TITLE
Fix missing dependency on Windows dotNetFramework 4.6.1

### DIFF
--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -30,7 +30,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
 
@@ -153,7 +153,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
     steps:
     - checkout: self
       clean: true

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -21,7 +21,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
 
@@ -149,7 +149,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
     - checkout: self

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -115,7 +115,7 @@ stages:
           BuildDropPath: $(signOutPath)
           Build_Repository_Uri: 'https://github.com/powershell/secretstore'
           PackageName: 'Microsoft.PowerShell.SecretStore'
-          PackageVersion: '1.0.5'
+          PackageVersion: '1.0.6'
 
     - pwsh: |
         $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'

--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -7,7 +7,7 @@ jobs:
   pool:
     name: 1ES
     demands:
-    - ImageOverride -equals MMS2019
+    - ImageOverride -equals PSMMS2019-Secure
   displayName: ${{ parameters.displayName }}
 
   steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.0.6 - 2022-01-27
+
+### Fixes
+
+- Fix for type initialization error on WindowsPowerShell (Issue #).
+
+### Changes
+
+### New Features
+
 ## 1.0.5 - 2021-10-5
 
 ### Fixes

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+Copyright (c) Microsoft Corporation.
 
-Copyright (c) 2020 PowerShell Team
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -12,7 +12,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,0 +1,37 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties.
+Microsoft makes certain open source code available at https://3rdpartysource.microsoft.com,
+or you may send a check or money order for US $5.00, including the product name,
+the open source component name, platform, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to the extent
+required to debug changes to any libraries licensed under the GNU Lesser General Public License.
+
+---------------------------------------------------------
+
+PowerShellStandard.Library 5.1.0 - MIT
+
+
+(c) 2008 VeriSign, Inc.
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -42,10 +42,28 @@ function DoBuild
         # build code and place it in the staging location
         Push-Location "${SrcPath}/code"
         try {
+            # Get dotnet.exe command path.
+            $dotnetCommand = Get-Command -Name 'dotnet' -ErrorAction Ignore
+
+            # Check for dotnet for Windows (we only build on Windows platforms).
+            if ($null -eq $dotnetCommand) {
+                Write-Verbose -Verbose -Message "dotnet.exe cannot be found in current path. Looking in ProgramFiles path."
+                $dotnetCommandPath = Join-Path -Path $env:ProgramFiles -ChildPath "dotnet\dotnet.exe"
+                $dotnetCommand = Get-Command -Name $dotnetCommandPath -ErrorAction Ignore
+                if ($null -eq $dotnetCommand) {
+                    throw "Dotnet.exe cannot be found: $dotnetCommandPath is unavailable for build."
+                }
+            }
+
+            Write-Verbose -Verbose -Message "dotnet.exe command found in path: $($dotnetCommand.Path)"
+
+            # Check dotnet version
+            Write-Verbose -Verbose -Message "DotNet version: $(& ($dotnetCommand) --version)"
+
             # Build source
             Write-Verbose -Verbose -Message "Building with configuration: $BuildConfiguration, framework: $BuildFramework"
             Write-Verbose -Verbose -Message "Building location: PSScriptRoot: $PSScriptRoot, PWD: $pwd"
-            dotnet publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath
+            & ($dotnetCommand) publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath
 
             # Place build results
             if (! (Test-Path -Path "$BuildSrcPath/${ModuleName}.dll"))

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -29,6 +29,14 @@ function DoBuild
     Write-Verbose -Verbose -Message "Copying help files to '$BuildOutPath'"
     copy-item -Recurse "${HelpPath}/${Culture}" "$BuildOutPath"
 
+    # Copy license
+    Write-Verbose -Verbose -Message "Copying LICENSE file to '$BuildOutPath'"
+    Copy-Item -Path "./LICENSE" -Dest "$BuildOutPath"
+
+    # Copy notice
+    Write-Verbose -Verbose -Message "Copying ThirdPartyNotices.txt to '$BuildOutPath'"
+    Copy-Item -Path "./ThirdPartyNotices.txt" -Dest "$BuildOutPath"
+
     if ( Test-Path "${SrcPath}/code" ) {
         Write-Verbose -Verbose -Message "Building assembly and copying to '$BuildOutPath'"
         # build code and place it in the staging location
@@ -56,6 +64,9 @@ function DoBuild
 
             Write-Verbose -Verbose "$BuildSrcPath/System.IO.FileSystem.AccessControl.dll to $BuildOutPath"
             Copy-Item -Path "$BuildSrcPath/System.IO.FileSystem.AccessControl.dll" -Dest "$BuildOutPath"
+
+            Write-Verbose -Verbose "$BuildSrcPath/System.Runtime.InteropServices.RuntimeInformation.dll to $BuildOutPath"
+            Copy-Item -Path "$BuildSrcPath/System.Runtime.InteropServices.RuntimeInformation.dll" -Dest "$BuildOutPath"
         }
         catch {
             # Write-Error "dotnet build failed with error: $_"

--- a/src/Microsoft.PowerShell.SecretStore.psd1
+++ b/src/Microsoft.PowerShell.SecretStore.psd1
@@ -11,7 +11,7 @@ NestedModules = @('.\Microsoft.PowerShell.SecretStore.Extension')
 RequiredModules = @('Microsoft.PowerShell.SecretManagement')
 
 # Version number of this module.
-ModuleVersion = '1.0.5'
+ModuleVersion = '1.0.6'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/code/Microsoft.PowerShell.SecretStore.csproj
+++ b/src/code/Microsoft.PowerShell.SecretStore.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretStore</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretStore</AssemblyName>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
-    <FileVersion>1.0.5</FileVersion>
-    <InformationalVersion>1.0.5</InformationalVersion>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
+    <FileVersion>1.0.6</FileVersion>
+    <InformationalVersion>1.0.6</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
dotNetFramework 4.6.1 does not include the InteropServices.RuntimeInformation types, that are needed by the module. Fix is to include the binary in the module package.

This PR also contains CI release changes to update the build image.