### PR TITLE
Use `RequiredResource` hashtable to specify PowerShell module versions

### DIFF
--- a/SecretStore.build.ps1
+++ b/SecretStore.build.ps1
@@ -73,7 +73,7 @@ task Package {
 }
 
 task Test {
-    Invoke-Pester -CI -Output Diagnostic
+    Invoke-Pester -CI
 }
 
 task Build BuildModule, BuildDocs

--- a/tools/installPSResources.ps1
+++ b/tools/installPSResources.ps1
@@ -6,10 +6,27 @@ param(
 )
 
 if ($PSRepository -eq "CFS" -and -not (Get-PSResourceRepository -Name CFS -ErrorAction SilentlyContinue)) {
-    Register-PSResourceRepository -Name CFS -Uri "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v3/index.json"
+    Register-PSResourceRepository -Name CFS -Uri "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShellGalleryMirror/nuget/v3/index.json"
 }
 
-Install-PSResource -Repository $PSRepository -TrustRepository -Name InvokeBuild
-Install-PSResource -Repository $PSRepository -TrustRepository -Name platyPS
-Install-PSResource -Repository $PSRepository -TrustRepository -Name Pester
-Install-PSResource -Repository $PSRepository -TrustRepository -Name Microsoft.PowerShell.SecretManagement
+# NOTE: Due to a bug in Install-PSResource with upstream feeds, we have to
+# request an exact version. Otherwise, if a newer version is available in the
+# upstream feed, it will fail to install any version at all.
+Install-PSResource -Verbose -TrustRepository -RequiredResource  @{
+    InvokeBuild = @{
+        version = "5.12.1"
+        repository = $PSRepository
+      }
+    platyPS = @{
+        version = "0.14.2"
+        repository = $PSRepository
+    }
+    Pester = @{
+        version = "5.7.1"
+        repository = $PSRepository
+    }
+    "Microsoft.PowerShell.SecretManagement" = @{
+        version = "1.1.2"
+        repository = $PSRepository
+    }
+}


### PR DESCRIPTION
Fixes OneBranch pipeline.